### PR TITLE
Fix missing <cstdint> include

### DIFF
--- a/lib/reachability/Query.h
+++ b/lib/reachability/Query.h
@@ -8,6 +8,8 @@
 #ifndef REACH_QUERY_H
 #define REACH_QUERY_H
 
+#include <cstdint>
+
 #include "extern/KaHIP/lib/definitions.h"
 
 struct Query {


### PR DESCRIPTION
Hey,

The compiler on my system required an explicit `#include <cstdint>` in `lib/reachability/Query.h` due to missing type definitions like `uint_fast8_t`, so I added the include to ensure compatibility.

Best,
Patrick